### PR TITLE
Fixing button irregularities on Payment Page

### DIFF
--- a/includes/class-paystack.php
+++ b/includes/class-paystack.php
@@ -795,7 +795,7 @@ class Tbz_WC_Paystack_Gateway extends WC_Payment_Gateway_CC {
 
 			echo '<p>Thank you for your order, please click the button below to pay with Paystack.</p>';
 
-			echo '<div id="paystack_form"><form id="order_review" method="post" action="'. WC()->api_request_url( 'Tbz_WC_Paystack_Gateway' ) .'"></form><button class="button alt" id="paystack-payment-button">Pay Now</button> <a class="button cancel" href="' . esc_url( $order->get_cancel_order_url() ) . '">Cancel order &amp; restore cart</a></div>
+			echo '<div id="paystack_form"><form id="order_review" method="post" action="'. WC()->api_request_url( 'Tbz_WC_Paystack_Gateway' ) .'"></form><button class="button alt" id="paystack-payment-button">Pay Now</button> <button class="button cancel"><a href="' . esc_url( $order->get_cancel_order_url() ) . '">Cancel order &amp; restore cart</a></button></div>
 				';
 
 		}


### PR DESCRIPTION
The "Cancel order & Restore Cart" button on the Payment page is not on the same line as the "Pay Now" button.